### PR TITLE
DDS-308 Add crates.io publish workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    # Pattern matched against refs/tags
+    tags:
+      - '*'           # Push events to every tag not containing /
+  workflow_dispatch:
+
+name: Publish to crates.io
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - run: cargo publish --package 'dust_dds_gen' --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_gen"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/src/mappings/rust.rs
+++ b/src/mappings/rust.rs
@@ -51,7 +51,7 @@ pub fn struct_member(member: idl::StructMember) -> String {
 
 pub fn struct_def(def: idl::Struct) -> impl Iterator<Item = String> {
     [
-        "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]\n".to_string(),
+        "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]\n".to_string(),
         format!("pub struct {} {{\n", def.name),
     ]
         .into_iter()
@@ -65,7 +65,7 @@ pub fn struct_def(def: idl::Struct) -> impl Iterator<Item = String> {
 
 pub fn enum_def(def: idl::Enum) -> impl Iterator<Item = String> {
     [
-        "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]\n".to_string(),
+        "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]\n".to_string(),
         format!("pub enum {} {{\n", def.name),
     ]
         .into_iter()
@@ -129,7 +129,7 @@ mod tests {
             })
             .collect::<Vec<String>>(),
             vec![
-                "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]\n",
+                "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]\n",
                 "pub struct Toto {\n",
                 "    pub a: i64,\n",
                 "    pub b: char,\n",
@@ -153,7 +153,7 @@ mod tests {
             })
             .collect::<Vec<String>>(),
             vec![
-                "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]\n",
+                "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]\n",
                 "pub enum Suit {\n",
                 "    Spades,\n",
                 "    Hearts,\n",
@@ -190,12 +190,12 @@ mod tests {
             .collect::<Vec<String>>(),
             vec![
                 "mod M {\n",
-                "    #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]\n",
+                "    #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]\n",
                 "    pub struct A {\n",
                 "        pub a: i16,\n",
                 "    }\n",
                 "    mod N {\n",
-                "        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]\n",
+                "        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]\n",
                 "        pub enum B {\n",
                 "            C,\n",
                 "            D,\n",

--- a/tests/examples/enums.rs
+++ b/tests/examples/enums.rs
@@ -1,11 +1,11 @@
-#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
 pub enum Suits {
     Spades,
     Hearts,
     Diamonds,
     Clubs,
 }
-#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
 pub enum Direction {
     North,
     East,

--- a/tests/examples/modules.rs
+++ b/tests/examples/modules.rs
@@ -1,6 +1,6 @@
 mod Game {
     mod Chess {
-        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
         pub enum ChessPiece {
             Pawn,
             Rook,
@@ -9,14 +9,14 @@ mod Game {
             Queen,
             King,
         }
-        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
         pub struct ChessSquare {
             pub column: char,
             pub line: u16,
         }
     }
     mod Cards {
-        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
         pub enum Suit {
             Spades,
             Hearts,
@@ -25,7 +25,7 @@ mod Game {
         }
     }
 }
-#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
 pub struct Point {
     pub x: f64,
     pub y: f64,

--- a/tests/examples/structs.rs
+++ b/tests/examples/structs.rs
@@ -1,24 +1,24 @@
-#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
 pub struct Point {
     pub x: f64,
     pub y: f64,
 }
-#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
 pub struct ChessSquare {
     #[key] pub column: char,
     #[key] pub line: u16,
 }
-#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
 pub struct HelloWorld {
     pub message: String,
     pub id: u32,
 }
-#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
 pub struct Sentence {
     pub words: Vec<String>,
     pub dependencies: Vec<[u32; 2]>,
 }
-#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsType)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::DdsType)]
 pub struct User {
     pub name: String,
 }


### PR DESCRIPTION
Add a github workflow that pushes dust-dds-gen to crates.io if a tag without a slash is pushed to this repository. Version is updated to 0.2.0. 